### PR TITLE
Add the ability to pipe a file into codicent

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Codicent CLI is a command-line interface for interacting with the Codicent API. 
    codicent "What can you help me with?"
    ```
 
+3. You can also pipe a file into `codicent`:
+   ```sh
+   codicent < chat.txt
+   cat chat.txt | codicent
+   ```
+
 ## Example
 
 ```sh

--- a/app.py
+++ b/app.py
@@ -11,10 +11,14 @@ def main():
         return
 
     if len(sys.argv) < 2:
-        print("Usage: codicent <question>")
-        return
+        if sys.stdin.isatty():
+            print("Usage: codicent <question> or codicent < chat.txt or cat chat.txt | codicent")
+            return
+        else:
+            question = sys.stdin.read().strip()
+    else:
+        question = " ".join(sys.argv[1:])
 
-    question = " ".join(sys.argv[1:])
     codicent = Codicent(token)
 
     reply = codicent.get_chat_reply(question)


### PR DESCRIPTION
Related to #1

Add support for piping a file into `codicent`.

* **app.py**
  - Modify the `main` function to read from standard input if no command-line arguments are provided.
  - Add logic to handle reading from a file if the input is piped.
  - Update the usage message to reflect the new usage options.

* **README.md**
  - Update the usage section to include examples of using 'codicent < chat.txt' and 'cat chat.txt | codicent'.
  - Add a note explaining the new functionality of reading from standard input.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/izaxon/codicent-cli/issues/1?shareId=2f2b41d6-81d6-4a6e-95c4-2b173f1f2a44).